### PR TITLE
[1.8] Update output folder for legacy saving

### DIFF
--- a/msi.gama.experimental.p2updatesite/pom.xml
+++ b/msi.gama.experimental.p2updatesite/pom.xml
@@ -17,12 +17,12 @@
 		<repository>
 			<uniqueVersion>false</uniqueVersion>
 			<id>p2Repo</id>
-			<url>scp://51.255.46.42/./var/www/gama_updates/experimental</url>
+			<url>scp://51.255.46.42/./var/www/gama_updates/experimental/1.8</url>
 		</repository>
 		<snapshotRepository>
 			<uniqueVersion>false</uniqueVersion>
 			<id>p2Repo</id>
-			<url>scp://51.255.46.42/./var/www/gama_updates/experimental</url>
+			<url>scp://51.255.46.42/./var/www/gama_updates/experimental/1.8</url>
 		</snapshotRepository>
 	</distributionManagement>
 
@@ -34,7 +34,7 @@
 			<properties>
 				<!-- Properties relative to the distant host where to upload the repo -->
 				<ftp.url>scp://51.255.46.42</ftp.url>
-				<ftp.toDir>./var/www/gama_updates/experimental</ftp.toDir>
+				<ftp.toDir>./var/www/gama_updates/experimental/1.8</ftp.toDir>
 				<!-- Relative path to the repo being uploaded -->
 				<repo.path>${project.build.directory}/repository/</repo.path>
 			</properties>


### PR DESCRIPTION
Will break raw compatibility with released GAMA 1.8, but this reason is explained in documentation and will allow a better evolution with new releases of GAMA and future compatibles plugins
Also, if merged, the current branch `master` should be renamed in `GAMA_1.8` to have the full repository consistant

- Related to PR #23